### PR TITLE
fixed #22 - Error: pop takes two arguments (line 195)

### DIFF
--- a/sunfish.py
+++ b/sunfish.py
@@ -292,7 +292,7 @@ def bound(pos, gamma, depth):
     if entry is None or depth >= entry.depth and best >= gamma:
         tp[pos] = Entry(depth, best, gamma, bmove)
         if len(tp) > TABLE_SIZE:
-            tp.pop()
+            tp.popitem()
     return best
 
 


### PR DESCRIPTION
Seems like the bug is easily fixable. I ran into it when modifying parameter values to see how they impacted performance. You can find information about OrderedDict's popitem at https://docs.python.org/2/library/collections.html#collections.OrderedDict

They're still using this convention in 3.5. 