### PR TITLE
Fix checking for stalemate

### DIFF
--- a/sunfish.py
+++ b/sunfish.py
@@ -283,7 +283,7 @@ def bound(pos, gamma, depth):
         return nullscore
     # Check for stalemate. If best move loses king, but not doing anything
     # would save us. Not at all a perfect check.
-    if depth > 0 and best <= -MATE_VALUE is None and nullscore > -MATE_VALUE:
+    if depth > 0 and best <= -MATE_VALUE and nullscore > -MATE_VALUE:
         best = 0
 
     # We save the found move together with the score, so we can retrieve it in


### PR DESCRIPTION
Remove superfluous "is None" which was accidentally left over from
the method used previously.

Note that finding stalemates is still problematic (e.g., even the first line of
tests/stalemate2.fen fails) because of nullmove pruning.