### PR TITLE
Consider the value of a captured piece in the rotated position

### DIFF
--- a/sunfish.py
+++ b/sunfish.py
@@ -213,7 +213,7 @@ class Position(namedtuple('Position', 'board score wc bc ep kp')):
         score = pst[p][j] - pst[p][i]
         # Capture
         if q.islower():
-            score += pst[q.upper()][j]
+            score += pst[q.upper()][len(self.board)-j-1]
         # Castling check detection
         if abs(j-self.kp) < 2:
             score += pst['K'][j]


### PR DESCRIPTION
I think that when capturing a piece we should consider the value of a captured piece in the rotated position, to keep the score coherent with the sum of the value of player pieces minus the sum of the value of the opponent pieces in the rotated position.