### PR TITLE
Fix parsing position uci command

### DIFF
--- a/uci.py
+++ b/uci.py
@@ -59,10 +59,28 @@ def main():
         elif smove == 'ucinewgame':
             stack.append('position fen ' + tools.FEN_INITIAL)
 
+        # syntax specified in UCI
+        # position [fen  | startpos ]  moves  ....
+
         elif smove.startswith('position fen'):
-            _, _, fen = smove.split(' ', 2)
+            idx=smove.find('moves')
+
+            if idx >= 0:
+                fenpart=smove[:idx]
+            else:
+                fenpart = smove
+
+            _, _, fen = fenpart.split(' ', 2)
+
             pos = tools.parseFEN(fen)
             color = WHITE if fen.split()[1] == 'w' else BLACK
+
+            if idx >= 0:
+                movespart=smove[idx:].split()
+
+                for move in movespart[1:]:
+                    pos = pos.move(tools.mparse(color, move))
+                    color = 1 - color
 
         elif smove.startswith('position startpos'):
             params = smove.split(' ')

--- a/uci.py
+++ b/uci.py
@@ -63,35 +63,35 @@ def main():
         # syntax specified in UCI
         # position [fen  | startpos ]  moves  ....
 
-        elif smove.startswith('position fen'):
+        elif smove.startswith('position'):
+            params = smove.split(' ')
             idx = smove.find('moves')
 
             if idx >= 0:
-                fenpart = smove[:idx]
+                moveslist = smove[idx:].split()[1:]
             else:
-                fenpart = smove
+                moveslist = []
 
-            _, _, fen = fenpart.split(' ', 2)
+            if params[1] == 'fen':
+                if idx >= 0:
+                    fenpart = smove[:idx]
+                else:
+                    fenpart = smove
+
+                _, _, fen = fenpart.split(' ', 2)
+
+            elif params[1] == 'startpos':
+                fen = tools.FEN_INITIAL
+
+            else:
+                pass
 
             pos = tools.parseFEN(fen)
             color = WHITE if fen.split()[1] == 'w' else BLACK
 
-            if idx >= 0:
-                movespart = smove[idx:].split()
-
-                for move in movespart[1:]:
-                    pos = pos.move(tools.mparse(color, move))
-                    color = 1 - color
-
-        elif smove.startswith('position startpos'):
-            params = smove.split(' ')
-            pos = tools.parseFEN(tools.FEN_INITIAL)
-            color = WHITE
-
-            if len(params) > 2 and params[2] == 'moves':
-                for move in params[3:]:
-                    pos = pos.move(tools.mparse(color, move))
-                    color = 1 - color
+            for move in moveslist:
+                pos = pos.move(tools.mparse(color, move))
+                color = 1 - color
 
         elif smove.startswith('go'):
             #  default options

--- a/uci.py
+++ b/uci.py
@@ -41,7 +41,8 @@ def main():
     while True:
         if stack:
             smove = stack.pop()
-        else: smove = input()
+        else:
+            smove = input()
 
         logging.debug(f'>>> {smove} ')
 
@@ -63,10 +64,10 @@ def main():
         # position [fen  | startpos ]  moves  ....
 
         elif smove.startswith('position fen'):
-            idx=smove.find('moves')
+            idx = smove.find('moves')
 
             if idx >= 0:
-                fenpart=smove[:idx]
+                fenpart = smove[:idx]
             else:
                 fenpart = smove
 
@@ -76,7 +77,7 @@ def main():
             color = WHITE if fen.split()[1] == 'w' else BLACK
 
             if idx >= 0:
-                movespart=smove[idx:].split()
+                movespart = smove[idx:].split()
 
                 for move in movespart[1:]:
                     pos = pos.move(tools.mparse(color, move))


### PR DESCRIPTION
Fixing uci.py to correctly handle a position command like the following one:

 position fen rnbqkbnr/ppp2ppp/8/3pp3/4P3/5P2/PPPP2PP/RNBQKBNR w KQkq - 0 3 moves c2c3

namely when both fen string and move list are specified as allowed by the syntax spefied in UCI protocol:

position [fen  | startpos ]  moves  ....

