### PR TITLE
Use 'in <literal>' instead of str.isupper/isspace/islower in gen_moves (+3.7% nps)

### DIFF
--- a/sunfish.py
+++ b/sunfish.py
@@ -154,14 +154,17 @@ class Position(namedtuple("Position", "board score wc bc ep kp")):
         # For each of our pieces, iterate through each possible 'ray' of moves,
         # as defined in the 'directions' map. The rays are broken e.g. by
         # captures or immediately in case of pieces such as knights.
+        # NB: `in <literal-str>` is ~30% faster than the equivalent .isupper() /
+        # .isspace() / .islower() method calls in CPython; this matters because
+        # these checks run millions of times per search.
         for i, p in enumerate(self.board):
-            if not p.isupper():
+            if p not in "PNBRQK":
                 continue
             for d in directions[p]:
                 for j in count(i + d, d):
                     q = self.board[j]
                     # Stay inside the board, and off friendly pieces
-                    if q.isspace() or q.isupper():
+                    if q in " \nPNBRQK":
                         break
                     # Pawn move, double move and capture
                     if p == "P":
@@ -182,7 +185,7 @@ class Position(namedtuple("Position", "board score wc bc ep kp")):
                     # Move it
                     yield Move(i, j, "")
                     # Stop crawlers from sliding, and sliding after captures
-                    if p in "PNK" or q.islower():
+                    if p in "PNK" or q in "pnbrqk":
                         break
                     # Castling, by sliding the rook next to the king
                     if i == A1 and self.board[j + E] == "K" and self.wc[0]:


### PR DESCRIPTION
## Summary

Replace three Python str-method calls in `Position.gen_moves` with literal-string `in` checks. The search tree is unchanged; the only thing that changes is how each char is classified inside the move-generator loop.

| | original | patched |
|---|---|---|
| `q.isupper()` | method call | `q in "PNBRQK"` |
| `q.isspace() or q.isupper()` | two method calls | `q in " \nPNBRQK"` |
| `q.islower()` | method call | `q in "pnbrqk"` |

## Why

`gen_moves` accounted for ~67% of CPython search time in a `cProfile` run of a 5-ply search from startpos. Inside it, the three str-methods above are called millions of times per search and each one is a Python-level attribute lookup plus a C call. Literal `in` is faster because CPython has a specialized opcode for it (`CONTAINS_OP`) that skips the method-lookup overhead.

`timeit` over a 120-char board scan, 100k iters, CPython 3.13:

```
c.isupper()                  3.33 us
c in "PNBRQK"                2.61 us   (~22% faster)
c.isspace() or c.isupper()   4.97 us
c in " \nPNBRQK"             3.34 us   (~33% faster)
c.islower()                  ~     (similar order)
c in "pnbrqk"                ~
```

## Speedup

A 6-position suite (startpos + 5 typical openings/middlegames) at fixed depth 5, 5 runs each, CPython 3.13 on Windows:

```
              original          patched
nps           16,711 – 17,240   17,592 – 17,685
mean          17,030            17,656
speedup       —                 +3.7%
```

The variance bands don't overlap across 5 runs, so this is reproducible — not noise.

## Correctness

- **Node-count identical**: every position at every depth produces the same node count between original and patched (123,142 across the depth-5 suite, both versions).
- **Perft**: matches across 6 standard positions at depth 3 — startpos = 8902, Kiwipete = 97862, position 3 = 2812, position 4 = 9467, promotion test = 62379, middlegame = 89890. Per-root-move breakdowns are also identical.
- **Mate-in-1 puzzles**: first 8 entries from `tools/test_files/mate1.fen` produce identical `bestmove` between original and patched.

## Notes on minimalism

`build/clean.sh sunfish.py | wc -l` is unchanged: 3 lines swapped 1:1 in `gen_moves`. The diff also adds a 3-line `# NB:` comment explaining why the literal form is used (so a future reader doesn't "clean up" back to method calls); comments are stripped by `clean.sh` so the 131-line claim is unaffected.

## Test plan

- [x] Run `perft_ab.py` (modified vs original) at depth 3 across 6 positions — totals and per-root-move breakdowns identical.
- [x] Run mate-in-1 cross-check on first 8 `mate1.fen` positions — identical `bestmove`.
- [x] Run `bench.py` at depth 4 and depth 5, 5 runs each — speedup is reproducible.
- [ ] (Upstream maintainer can verify) `tools/quick_tests.sh` end-to-end.
