### PR TITLE
fix: correct typo self.ec to self.wc in sunfish_nnue.py

### DIFF
--- a/sunfish_nnue.py
+++ b/sunfish_nnue.py
@@ -214,7 +214,7 @@ class Position(namedtuple("Position", "board score wf bf wc bc ep kp")):
         # We make this stack to keep track of what we change
         stack = []
 
-        old_ep, old_kp, old_wc, old_bc = self.ep, self.kp, self.ec, self.bc
+        old_ep, old_kp, old_wc, old_bc = self.ep, self.kp, self.wc, self.bc
         self.ep, self.kp = 0, 0
 
         # Actual move
@@ -258,7 +258,7 @@ class Position(namedtuple("Position", "board score wf bf wc bc ep kp")):
             self.put(i, q)
 
         # And restore the fields
-        self.ep, self.kp, self.ec, self.bc = old_ep, old_kp, old_wc, old_bc
+        self.ep, self.kp, self.wc, self.bc = old_ep, old_kp, old_wc, old_bc
 
     def is_capture(self, move):
         # The original sunfish just checked that the evaluation of a move


### PR DESCRIPTION
## Summary

Fixes a typo on lines 217 and 261 of sunfish_nnue.py where \self.ec\ was used instead of \self.wc\.

## Changes

- Line 217: \self.ec\ -> \self.wc\ (saving castling rights before move generation)
- Line 261: \self.ec\ -> \self.wc\ (restoring castling rights after move generation)

## Motivation

Fixes #120. The field \self.ec\ does not exist on the Position class. The correct field is \self.wc\ (white castling rights), matching the destructuring pattern \old_ep, old_kp, old_wc, old_bc\.

## Testing

Two-character fix. The code was previously referencing a non-existent attribute, so this corrects the logic to match the original sunfish.py implementation.